### PR TITLE
More consistent squirrels 

### DIFF
--- a/src/shipit.coffee
+++ b/src/shipit.coffee
@@ -22,7 +22,6 @@ squirrels = [
   "http://images.cheezburger.com/completestore/2011/11/2/46e81db3-bead-4e2e-a157-8edd0339192f.jpg",
   "http://28.media.tumblr.com/tumblr_lybw63nzPp1r5bvcto1_500.jpg",
   "http://i.imgur.com/DPVM1.png",
-  "http://gifs.gifbin.com/092010/1285616410_ship-launch-floods-street.gif",
   "http://d2f8dzk2mhcqts.cloudfront.net/0772_PEW_Roundup/09_Squirrel.jpg",
   "http://www.cybersalt.org/images/funnypictures/s/supersquirrel.jpg",
   "http://www.zmescience.com/wp-content/uploads/2010/09/squirrel.jpg",


### PR DESCRIPTION
Am a huge fan of the 'ship it' images but the one that seems out of place is the ship flooding the street.  Suggest removing it to keep the humor consistent and reliable.

It may be worth it to then even remove these 2, to keep a more reliable squirrel experience.  
- http://i.imgur.com/DPVM1.png
- http://images.cheezburger.com/completestore/2011/11/2/aa83c0c4-2123-4bd3-8097-966c9461b30c.jpg
