### PR TITLE
Remove 404ing imageshack links

### DIFF
--- a/src/shipit.coffee
+++ b/src/shipit.coffee
@@ -25,8 +25,6 @@ squirrels = [
   "http://d2f8dzk2mhcqts.cloudfront.net/0772_PEW_Roundup/09_Squirrel.jpg",
   "http://www.cybersalt.org/images/funnypictures/s/supersquirrel.jpg",
   "http://www.zmescience.com/wp-content/uploads/2010/09/squirrel.jpg",
-  "http://img70.imageshack.us/img70/4853/cutesquirrels27rn9.jpg",
-  "http://img70.imageshack.us/img70/9615/cutesquirrels15ac7.jpg",
   "https://dl.dropboxusercontent.com/u/602885/github/sniper-squirrel.jpg",
   "http://1.bp.blogspot.com/_v0neUj-VDa4/TFBEbqFQcII/AAAAAAAAFBU/E8kPNmF1h1E/s640/squirrelbacca-thumb.jpg",
   "https://dl.dropboxusercontent.com/u/602885/github/soldier-squirrel.jpg",


### PR DESCRIPTION
It is with a heavy heart that I must announce that the two classic all-time-favourites `cutesquirrels27rn9.jpg` and `cutesquirrels15ac7.jpg` are gone from the interweb.
